### PR TITLE
Added time interval merging

### DIFF
--- a/static/js/transcript-editing.js
+++ b/static/js/transcript-editing.js
@@ -88,7 +88,7 @@ function deleteTranscript() {
     // if any word has been selected, then update the video
         selectedWordsArr.forEach(element => {
             console.log(element);
-            timestamps["timestamps"].push([element.getAttribute("data-start"), element.getAttribute("data-stop")]);
+            timestamps["timestamps"].push([parseFloat(element.getAttribute("data-start")), parseFloat(element.getAttribute("data-stop"))]);
             element.remove();
         });
 


### PR DESCRIPTION
This PR adds functionality to merge video cuts within a configurable interval. As of now, this interval is 0.1 seconds, but this can be anything. We also merge from the start, but not the end as of now, although this could be implemented at a later date.
We also sort the incoming timestamps, so now out of order cuts will no longer cause weird results.

For example, consider this list of cuts:

`[0.01, 0.09], [0.1, 0.4], [0.45, 0.46], [0.46, 0.49], [0.6, 0.7], [0.9, 1], [1, 1.5]]`

This will merge into this, using the 0.1 second merge value:

`[[0, 0.49], [0.6, 0.7], [0.9, 1.5]]`

Please let me know if anything needs changing.